### PR TITLE
added subtitle check

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ utils.loadMediumPost(mediumURL, function(err, json) {
 
   story.markdown = [];
   story.markdown.push("\n# "+story.title.replace(/\n/g,'\n# '));
-  story.markdown.push("\n## "+story.subtitle.replace(/\n/g,'\n## '));
+  if (undefined != story.subtitle) {
+    story.markdown.push("\n## "+story.subtitle.replace(/\n/g,'\n## '));
+  }
   for(var i=0;i<story.paragraphs.length;i++) {
     
     if(sections[i]) story.markdown.push(sections[i]);


### PR DESCRIPTION
I tried running this on my article here: https://medium.com/@werdnanoslen/mozillas-open-leadership-training-can-work-for-open-austin-projects-7e3e23548c6f, and it failed because the subtitle was undefined. So I suppose either subtitles aren't required, or they've deprecated it (check API to confirm). Nice script, though! Made my task super easy. :)