### PR TITLE
add ability to parse entire feeds

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,4 @@
+module.exports = {
+  getFeed: require('./get-feed'),
+  getPost: require('./get-post'),
+}

--- a/get-feed.js
+++ b/get-feed.js
@@ -6,17 +6,18 @@ var rssParser = require('rss-parser')
 module.exports = function(feedURL, program, callback) {
   let outputDir = program.output || process.cwd();
   rssParser.parseURL(feedURL, function(err, data) {
+    if (err) return callback(err);
     Promise.all(data.feed.entries.map(entry => {
       return new Promise((resolve, reject) => {
         getPost(entry.link, program, function(err, text) {
           if (err) return reject(err);
-          let filename = path.join(outputDir, entry.title.replace(/\W+/g, '_') + '.md');
-          fs.writeFile(filename, text, err => {
+          entry.filename = path.join(outputDir, entry.title.replace(/\W+/g, '_') + '.md');
+          fs.writeFile(entry.filename, text, err => {
             if (err) return reject(err);
             resolve(text);
           })
         });
       })
-    })).then(_ => callback && callback());
+    })).then(_ => callback && callback(null, data));
   })
 }

--- a/get-feed.js
+++ b/get-feed.js
@@ -1,0 +1,22 @@
+var rssParser = require('rss-parser')
+  , fs = require('fs')
+  , path = require('path')
+  , getPost = require('./get-post');
+
+module.exports = function(feedURL, program, callback) {
+  let outputDir = program.output || process.cwd();
+  rssParser.parseURL(feedURL, function(err, data) {
+    Promise.all(data.feed.entries.map(entry => {
+      return new Promise((resolve, reject) => {
+        getPost(entry.link, program, function(err, text) {
+          if (err) return reject(err);
+          let filename = path.join(outputDir, entry.title.replace(/\W+/g, '_') + '.md');
+          fs.writeFile(filename, text, err => {
+            if (err) return reject(err);
+            resolve(text);
+          })
+        });
+      })
+    })).then(_ => callback && callback());
+  })
+}

--- a/get-post.js
+++ b/get-post.js
@@ -20,10 +20,13 @@ module.exports = function(mediumURL, program, callback) {
       process.exit(0);
     }
 
+    var outputText = '';
+
     if(program.headers) {
-      console.log("url: "+story.url);
-      console.log("date: "+story.date);
-      console.log(program.separator);
+      outputText += 'url:' + story.url + '\n';
+      outputText += 'date:' + story.date + '\n';
+      outputText += 'title:' + story.title + '\n';
+      outputText += program.separator + '\n';
     }
 
     story.sections = s.content.bodyModel.sections;
@@ -73,15 +76,15 @@ module.exports = function(mediumURL, program, callback) {
       if (program.debug) {
         console.log("debug", story.paragraphs);
       }
-      let text = story.markdown.join('\n');
+      outputText += story.markdown.join('\n');
       if (callback) {
-        callback(null, text);
+        callback(null, outputText);
       } else if (program.output) {
-        fs.writeFile(program.output, text, err => {
+        fs.writeFile(program.output, outputText, err => {
           if (err) throw err;
         })
       } else {
-        console.log(text);
+        console.log(outputText);
       }
     });
 

--- a/get-post.js
+++ b/get-post.js
@@ -1,0 +1,89 @@
+var utils = require('./utils')
+  , fs = require('fs')
+  , Promise = require('bluebird')
+  ;
+
+module.exports = function(mediumURL, program, callback) {
+  utils.loadMediumPost(mediumURL, function(err, json) {
+
+    var s = json.payload.value;
+    var story = {};
+
+    story.title = s.title;
+    story.date = new Date(s.createdAt);
+    story.url = s.canonicalUrl;
+    story.language = s.detectedLanguage;
+    story.license = s.license;
+
+    if(program.info) {
+      console.log(story);
+      process.exit(0);
+    }
+
+    if(program.headers) {
+      console.log("url: "+story.url);
+      console.log("date: "+story.date);
+      console.log(program.separator);
+    }
+
+    story.sections = s.content.bodyModel.sections;
+    story.paragraphs = s.content.bodyModel.paragraphs;
+
+    var sections = [];
+    for(var i=0;i<story.sections.length;i++) {
+      var s = story.sections[i];
+      var section = utils.processSection(s);
+      sections[s.startIndex] = section;
+    }
+
+    if(story.paragraphs.length > 1) {
+      story.subtitle = story.paragraphs[1].text;
+    }
+
+    story.markdown = [];
+    story.markdown.push("\n# "+story.title.replace(/\n/g,'\n# '));
+    if (undefined != story.subtitle) {
+      story.markdown.push("\n"+story.subtitle.replace(/#+/,''));
+    }
+
+    var promises = [];
+
+    for(var i=2;i<story.paragraphs.length;i++) {
+      
+      if(sections[i]) story.markdown.push(sections[i]);
+
+      var promise = new Promise(function (resolve, reject) {
+        var p = story.paragraphs[i];
+        utils.processParagraph(p, function(err, text) {
+          // Avoid double title/subtitle
+          if(text != story.markdown[i])
+            return resolve(text);
+          else
+            return resolve();
+        });
+      });
+      promises.push(promise);
+    }
+
+    Promise.all(promises).then((results) => {
+      results.map(text => {
+        story.markdown.push(text);
+      })
+
+      if (program.debug) {
+        console.log("debug", story.paragraphs);
+      }
+      let text = story.markdown.join('\n');
+      if (callback) {
+        callback(null, text);
+      } else if (program.output) {
+        fs.writeFile(program.output, text, err => {
+          if (err) throw err;
+        })
+      } else {
+        console.log(text);
+      }
+    });
+
+  });
+}

--- a/get-post.js
+++ b/get-post.js
@@ -49,6 +49,16 @@ module.exports = function(mediumURL, program, callback) {
       story.markdown.push("\n"+story.subtitle.replace(/#+/,''));
     }
 
+    let lastParagraph = null;
+    story.paragraphs = story.paragraphs.filter((p, idx) => {
+      if (p.type === 8 && lastParagraph && lastParagraph.type === 8) {
+        lastParagraph.text += '\n\n' + p.text;
+        return false;
+      }
+      lastParagraph = p;
+      return true;
+    })
+
     var promises = [];
 
     for(var i=2;i<story.paragraphs.length;i++) {

--- a/index.js
+++ b/index.js
@@ -1,23 +1,23 @@
 #! /usr/bin/env node
 
 var program = require('commander')
-  , utils = require('./utils')
   , package = require('./package.json')
-  , Promise = require('bluebird')
   ;
 
 program
   .version(package.version)
   .description(package.description)
-  .usage('[options] <medium post url>')
+  .usage('[options] <medium post or feed url>')
   .option('-H, --headers', 'Add headers at the beginning of the markdown file with metadata')
   .option('-S, --separator <separator>', 'Separator between headers and body','')
   .option('-I, --info', 'Show information about the medium post')
+  .option('-O, --output <destination>', 'File (if URL is a post) or directory (if URL is a feed) to output to')
   .option('-d, --debug', 'Show debugging info')
   .on('--help', function(){
     console.log('  Examples:');
     console.log('');
     console.log('    $ mediumexporter https://medium.com/@xdamman/my-10-day-meditation-retreat-in-silence-71abda54940e > medium_post.md');
+    console.log('    $ mediumexporter -o ./posts https://medium.com/feed/@xdamman');
     console.log('    $ mediumexporter --headers --separator --- https://medium.com/@xdamman/my-10-day-meditation-retreat-in-silence-71abda54940e > medium_post.md');
     console.log('    $ mediumexporter mediumpost.json');
     console.log('');
@@ -27,76 +27,9 @@ program.parse(process.argv);
 
 var mediumURL = program.args[0];
 
-utils.loadMediumPost(mediumURL, function(err, json) {
+if (mediumURL.match(/medium\.com\/feed\//)) {
+  require('./get-feed')(mediumURL, program);
+} else {
+  require('./get-post')(mediumURL, program);
+}
 
-  var s = json.payload.value;
-  var story = {};
-
-  story.title = s.title;
-  story.date = new Date(s.createdAt);
-  story.url = s.canonicalUrl;
-  story.language = s.detectedLanguage;
-  story.license = s.license;
-
-  if(program.info) {
-    console.log(story);
-    process.exit(0);
-  }
-
-  if(program.headers) {
-    console.log("url: "+story.url);
-    console.log("date: "+story.date);
-    console.log(program.separator);
-  }
-
-  story.sections = s.content.bodyModel.sections;
-  story.paragraphs = s.content.bodyModel.paragraphs;
-
-  var sections = [];
-  for(var i=0;i<story.sections.length;i++) {
-    var s = story.sections[i];
-    var section = utils.processSection(s);
-    sections[s.startIndex] = section;
-  }
-
-  if(story.paragraphs.length > 1) {
-    story.subtitle = story.paragraphs[1].text;
-  }
-
-  story.markdown = [];
-  story.markdown.push("\n# "+story.title.replace(/\n/g,'\n# '));
-  if (undefined != story.subtitle) {
-    story.markdown.push("\n"+story.subtitle.replace(/#+/,''));
-  }
-
-  var promises = [];
-
-  for(var i=2;i<story.paragraphs.length;i++) {
-    
-    if(sections[i]) story.markdown.push(sections[i]);
-
-    var promise = new Promise(function (resolve, reject) {
-      var p = story.paragraphs[i];
-      utils.processParagraph(p, function(err, text) {
-        // Avoid double title/subtitle
-        if(text != story.markdown[i])
-          return resolve(text);
-        else
-          return resolve();
-      });
-    });
-    promises.push(promise);
-  }
-
-  Promise.all(promises).then((results) => {
-    results.map(text => {
-      story.markdown.push(text);
-    })
-
-    if (program.debug) {
-      console.log("debug", story.paragraphs);
-    }
-    console.log(story.markdown.join('\n'));
-  });
-
-});

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
     console.log('  Examples:');
     console.log('');
     console.log('    $ mediumexporter https://medium.com/@xdamman/my-10-day-meditation-retreat-in-silence-71abda54940e > medium_post.md');
-    console.log('    $ mediumexporter -o ./posts https://medium.com/feed/@xdamman');
+    console.log('    $ mediumexporter -O ./posts https://medium.com/feed/@xdamman');
     console.log('    $ mediumexporter --headers --separator --- https://medium.com/@xdamman/my-10-day-meditation-retreat-in-silence-71abda54940e > medium_post.md');
     console.log('    $ mediumexporter mediumpost.json');
     console.log('');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "commander": "^2.8.1",
-    "request": "^2.60.0"
+    "request": "^2.60.0",
+    "rss-parser": "^2.10.6"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mediumexporter",
   "version": "0.1.6",
   "description": "Export posts from medium.com to markdown",
-  "main": "index.js",
+  "main": "entry.js",
   "directories": {
     "test": "test"
   },

--- a/utils.js
+++ b/utils.js
@@ -78,6 +78,12 @@ var utils = {
       p.text = tokens.join('');
     }
 
+    if (p.type !== 8 && p.type !== 10) {
+      p.text = p.text
+          .replace(/>/g, '&gt;')
+          .replace(/</g, '&lt;');
+    }
+
     var markup = "";
     switch(p.type) {
       case 1:

--- a/utils.js
+++ b/utils.js
@@ -6,7 +6,7 @@ var utils = {
   loadMediumPost: function(mediumURL, cb) {
     if(mediumURL.match(/^http/i)) {
       mediumURL = mediumURL.replace(/#.+$/, '');
-      request(mediumURL+"?format=json", function(err, res, body) {
+      request(mediumURL, {qs: {format: 'json'}}, function(err, res, body) {
         if(err) return cb(err);
         var json_string = body.substr(body.indexOf('{'));
         var json = JSON.parse(json_string);

--- a/utils.js
+++ b/utils.js
@@ -51,7 +51,8 @@ var utils = {
           line = line
               .replace(/\\n\s*/g, '\n')
               .replace(/\n+/g, '\n')
-              .replace(/\\(.)/g, '$1');
+              .replace(/\\(.)/g, '$1')
+              .replace(/`/g, '&#96;');
           return line;
         }).join('\n');
         return cb(null, html);

--- a/utils.js
+++ b/utils.js
@@ -105,7 +105,7 @@ var utils = {
         p.text = "> # "+p.text.replace(/\n/g,'\n> # ');
         break;
       case 8:
-        p.text = "\n    "+p.text.replace(/\n/g,'\n    ');
+        p.text = "\n```\n" + p.text + "\n```\n";
         break;
       case 9:
         markup = "\n* ";


### PR DESCRIPTION
Hey, I wanted the ability to parse my entire Medium.com RSS feed. I figure I'm probably not the only one.

I kept the existing usage functional (i.e. printing to STDOUT) but added an `--output` option to either direct output to a file, or to a directory if we're parsing a feed. The resulting filenames are generated using the post's title, removing special chars.

Most of index.js has been moved to get-post.js. The only change there is at the end, where the resulting text is passed to the callback if present, and otherwise is sent to `console.log()`.

Hope this is helpful - happy to refactor if there's anything you want to change.