### PR TITLE
Add Jekyll formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Export your stories published on medium.com to markdown.
         -I, --info – Show information about the medium post
         --hugo - enable gohugo.io shortcodes
         --frontmatter - enable frontmatter
+        --jekyll - format content and images for us in Jekyll blogs
 
 ## CLI example
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ if (require.main !== module) {
       'File (if URL is a post) or directory (if URL is a feed) to output to'
     )
     .option('--hugo', 'use gohugo.io specific shortcodes')
+    .option(
+      '--jekyll',
+      'prefix the files with date, place images in an assets/'
+    )
     .option('--frontmatter', 'enable markdown frontmatter')
     .option('-d, --debug', 'Show debugging info')
     .on('--help', function() {

--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -65,7 +65,7 @@ module.exports = async function(mediumURL, params = {}) {
   const sections = []
   for (let i = 0; i < story.sections.length; i++) {
     const s = story.sections[i]
-    const section = utils.processSection(s, images, options)
+    const section = utils.processSection(s, story.slug, images, options)
     sections[s.startIndex] = section
   }
 
@@ -97,7 +97,8 @@ module.exports = async function(mediumURL, params = {}) {
 
     const promise = new Promise(function(resolve, reject) {
       const p = story.paragraphs[i]
-      const text = utils.processParagraph(p, images, options)
+
+      const text = utils.processParagraph(p, story.slug, images, options)
       return resolve(text)
     })
     promises.push(promise)
@@ -108,6 +109,9 @@ module.exports = async function(mediumURL, params = {}) {
       if (!!images.length) {
         let featuredImage = story.featuredImage
         let outputPath = path.join(output, story.slug, 'images')
+        if (!!options.jekyll) {
+          outputPath = path.join(output, `assets/images/${story.slug}`)
+        }
         createFolder(outputPath)
         story.images = await utils.downloadImages(images, {
           featuredImage: featuredImage,
@@ -131,10 +135,10 @@ module.exports = async function(mediumURL, params = {}) {
         outputText = '---\n'
         outputText += `slug: ${story.slug}\n`
         outputText += `date: ${story.date}\n`
-        outputText += `author: ${story.author}\n`
-        outputText += `title: ${story.title}\n`
+        outputText += `author: "${story.author}"\n`
+        outputText += `title: "${story.title}"\n`
         if (story.subtitle) {
-          outputText += `subtitle: ${story.subtitle}\n`
+          outputText += `subtitle: "${story.subtitle}"\n`
         }
         if (story.images.length > 0) {
           outputText += 'images:\n'
@@ -158,8 +162,12 @@ module.exports = async function(mediumURL, params = {}) {
       outputText += story.markdown.join('\n')
 
       let outputPath = `${output}/${story.slug}.md`
+
+      if (!!options.jekyll) {
+        outputPath = `${output}/${story.date.slice(0, 10)}-${story.slug}.md`
+      }
       if (output) {
-        if (!!images.length) {
+        if (!!images.length && !options.jekyll) {
           outputPath = path.join(output, story.slug) + '/index.md'
         }
         fs.writeFileSync(outputPath, outputText)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,14 +40,18 @@ async function loadMediumPost(mediumURL, options = {}) {
   }
 }
 
-function processSection(s, images, options = {}) {
-  const section = ''
+function processSection(s, slug, images, options = {}) {
+  let section = ''
   if (s.backgroundImage) {
     const imgwidth = parseInt(s.backgroundImage.originalWidth, 10)
     const imgsrc =
       MEDIUM_IMG_CDN + Math.max(imgwidth * 2, 2000) + '/' + s.backgroundImage.id
     images.push(imgsrc)
     section = '\n![](' + s.backgroundImage.id + ')'
+    if (!!options.jekyll) {
+      section = `\n![](/assets/images/${options.imageFolder +
+        s.backgroundImage.id})`
+    }
   }
   return section
 }
@@ -106,7 +110,7 @@ async function getGitHubEmbed(iframesrc, options = {}) {
   }
 }
 
-async function processParagraph(p, images, options = {}) {
+async function processParagraph(p, slug, images, options = {}) {
   const markups_array = createMarkupsArray(p.markups)
 
   if (markups_array.length > 0) {
@@ -147,6 +151,9 @@ async function processParagraph(p, images, options = {}) {
         MEDIUM_IMG_CDN + Math.max(imgwidth * 2, 2000) + '/' + p.metadata.id
       images.push(imgsrc)
       let text = '\n![' + p.text + '](' + p.metadata.id + ')'
+      if (!!options.jekyll) {
+        text = `\n![${p.text}](/assets/images/${slug}/${p.metadata.id})`
+      }
       if (p.text) {
         text += '*' + p.text + '*'
       }


### PR DESCRIPTION
Hi! Thanks a lot for making this tool! Found it very useful to export content from Medium blogs.

I thought the tool could benefit from being able to export content ready for Jekyll blogs. I've made the following changes:
- Listening for a `--jekyll` option
- Prefix all files with the date
- Place images all into a single `assets/images/` directory
- Wrap frontmatter string in double quotes to prevent build errors

Everything except the double quotes around frontmatter strings is all conditional with the `--jekyll` option.

It's not perfect, but I've tested it and it works a treat! Hope you appreciate this