### PR TITLE
fix issue with invalid characters in downloaded filenames

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const r2 = require('r2')
 const fs = require('fs')
+const sanitize = require('sanitize-filename')
 
 const MEDIUM_IMG_CDN = 'https://cdn-images-1.medium.com/max/'
 let mentionedUsers = []
@@ -8,7 +9,7 @@ async function downloadImages(images, options = {}) {
   const articleImages = []
 
   for (const image of images) {
-    let file = image.split('/')[image.split('/').length - 1]
+    let file = sanitize(image.split('/')[image.split('/').length - 1])
 
     if (options.featuredImage && options.featuredImage === file) {
       let type = file.split('.')[file.split('.').length - 1]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8749,6 +8749,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -9606,6 +9614,14 @@
       "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
       "dev": true
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-node": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.2.tgz",
@@ -9872,6 +9888,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "commander": "^2.19.0",
     "r2": "^2.0.1",
     "rss-parser": "^3.6.2",
-    "underscore.string": "^3.3.5"
+    "underscore.string": "^3.3.5",
+    "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {
     "codecov": "^3.1.0",


### PR DESCRIPTION
PR for issue #22 

uses https://www.npmjs.com/package/sanitize-filename / https://github.com/parshap/node-sanitize-filename to sanitize filenames when they're downloaded so the exporter doesn't crash hopefully