### PR TITLE
Add 'returnObject' option to getPost

### DIFF
--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -45,6 +45,24 @@ module.exports = async function(mediumURL, params = {}) {
     story.license = s.license
   }
 
+  // If the author's not available, get it from somewhere else
+  let authors = []
+  if (json.payload.references && json.payload.references.User) {
+    Object.keys(json.payload.references.User).forEach(k => {
+      let u = json.payload.references.User[k]
+      authors.push({
+        name: u.name,
+        username: u.username,
+        userId: u.userId
+      })
+    })
+    story.authors = authors
+
+    if (!story.author) {
+      story.author = authors[0].name
+    }
+  }
+
   if (s.virtuals.previewImage) {
     story.featuredImage = s.virtuals.previewImage.imageId
   }

--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -171,7 +171,8 @@ module.exports = async function(mediumURL, params = {}) {
           outputPath = path.join(output, story.slug) + '/index.md'
         }
         fs.writeFileSync(outputPath, outputText)
-        return
+        // return post object if required, else just exit
+        return options.returnObject ? story : undefined
       } else if (!output && params && params.commands) {
         console.log(outputText)
         return outputText


### PR DESCRIPTION
I added a `returnObject` option so that it's easier to integrate this into other command-line tools (eg. in case I want to do some additional processing on the article after it's fetched, display a `${post.title} was fetched successfully` message, etc.

I hope this gels with the rest of the programmatic options?