### PR TITLE
Automatically generate slug if not provided

### DIFF
--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -45,6 +45,11 @@ module.exports = async function(mediumURL, params = {}) {
     story.license = s.license
   }
 
+  // set slug if not already available
+  if (!story.slug) {
+    story.slug = slugify(story.title)
+  }
+
   // If the author's not available, get it from somewhere else
   let authors = []
   if (json.payload.references && json.payload.references.User) {


### PR DESCRIPTION
This is an issue with Medium drafts, where a slug is not set yet. mediumexporter tries to save it using an empty string (""), which results in a file named `.md` or the `images` folder being created in the main content directory rather than in a subfolder.

By automatically setting the slug, mediumexporter can ensure that each story gets saved in its own  directory