### PR TITLE
Allow getPost to receive JSON as argument instead of downloading

### DIFF
--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -19,14 +19,24 @@ function createFolder(path) {
 
 module.exports = async function(mediumURL, params = {}) {
   options = params
+  var json
 
-  if (!mediumURL || mediumURL.substr(0, 18) !== 'https://medium.com') {
-    throw new Error('no url or not a medium.com url')
+  if (options.postJSON) {
+    // load JSON locally
+    json = options.postJSON
+  } else {
+
+    // load JSON from online
+    if (!mediumURL || mediumURL.substr(0, 18) !== 'https://medium.com') {
+      throw new Error('no url or not a medium.com url')
+    }
+
+    json = await utils.loadMediumPost(mediumURL, options)
   }
 
-  let output = null
-  const json = await utils.loadMediumPost(mediumURL, options)
   const s = json.payload.value
+
+  let output = null
   const story = {}
   const images = []
 


### PR DESCRIPTION
This will be useful when using mediumexporter as part of a script (if we've already fetched the post, we can just pass on the JSON instead of passing on the whole post itself).