### PR TITLE
fix URL check to allow 3rd party domains

### DIFF
--- a/lib/get-post.js
+++ b/lib/get-post.js
@@ -20,7 +20,7 @@ function createFolder(path) {
 module.exports = async function(mediumURL, params = {}) {
   options = params
 
-  if (!mediumURL || mediumURL.substr(0, 18) !== 'https://medium.com') {
+  if (!mediumURL) {
     throw new Error('no url or not a medium.com url')
   }
 


### PR DESCRIPTION
This will loosen the restriction for `https://medium.com` URLs to allow downloading from 3rd party domains that host at medium.com, like [https://towardsdatascience.com/](https://towardsdatascience.com/).