### PR TITLE
make links to assets relative

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,7 @@ function processSection(s, slug, images, options = {}) {
     images.push(imgsrc)
     section = '\n![](' + s.backgroundImage.id + ')'
     if (!!options.jekyll) {
-      section = `\n![](/assets/images/${options.imageFolder +
+      section = `\n![](assets/images/${options.imageFolder +
         s.backgroundImage.id})`
     }
   }
@@ -153,7 +153,7 @@ async function processParagraph(p, slug, images, options = {}) {
       images.push(imgsrc)
       let text = '\n![' + p.text + '](' + p.metadata.id + ')'
       if (!!options.jekyll) {
-        text = `\n![${p.text}](/assets/images/${slug}/${p.metadata.id})`
+        text = `\n![${p.text}](assets/images/${slug}/${p.metadata.id})`
       }
       if (p.text) {
         text += '*' + p.text + '*'


### PR DESCRIPTION
This commit fixes the link to the `assets` directory (where images are downloaded to when running markdownexporter with the `--jekyll` flag), which used to be an absolute path (starting with `/`) and therefore caused file-not-found problems.