### PR TITLE
sanitize image filename in links

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,10 +48,10 @@ function processSection(s, slug, images, options = {}) {
     const imgsrc =
       MEDIUM_IMG_CDN + Math.max(imgwidth * 2, 2000) + '/' + s.backgroundImage.id
     images.push(imgsrc)
-    section = '\n![](' + s.backgroundImage.id + ')'
+    section = '\n![](' + sanitize(s.backgroundImage.id) + ')'
     if (!!options.jekyll) {
       section = `\n![](/assets/images/${options.imageFolder +
-        s.backgroundImage.id})`
+        sanitize(s.backgroundImage.id)})`
     }
   }
   return section
@@ -151,9 +151,11 @@ async function processParagraph(p, slug, images, options = {}) {
       const imgsrc =
         MEDIUM_IMG_CDN + Math.max(imgwidth * 2, 2000) + '/' + p.metadata.id
       images.push(imgsrc)
-      let text = '\n![' + p.text + '](' + p.metadata.id + ')'
+      let text = '\n![' + p.text + '](' + sanitize(p.metadata.id) + ')'
       if (!!options.jekyll) {
-        text = `\n![${p.text}](/assets/images/${slug}/${p.metadata.id})`
+        text = `\n![${p.text}](/assets/images/${slug}/${sanitize(
+          p.metadata.id
+        )})`
       }
       if (p.text) {
         text += '*' + p.text + '*'


### PR DESCRIPTION
This commit fixes the issue that image filename used to be sanitized when downloading image files but not in links, which therefore pointed to non-existing files.